### PR TITLE
using fast-image-resize crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   filters no longer exist. Furthermore, the filters `Bilinear` and `Mitchell`
   were added.
 
-* deleted previously deprecated `init -i` and `init -c` options
+  * deleted previously deprecated `init -i` and `init -c` options
 
 ### 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Unreleased
 
+  * BREAKING CHANGE: we are using fast_image_resize to resize our images now.
+  This makes resizing much faster (enough to smoothly play animations before
+  caching is done), but it makes it so that the `Gaussian` and `Triangle`
+  filters no longer exist. Furthermore, the filters `Bilinear` and `Mitchell`
+  were added.
+
 * deleted previously deprecated `init -i` and `init -c` options
 
 ### 0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87eba3c8c7f42ef17f6c659fc7416d0f4758cd3e58861ee63c5fa4a4dde649e4"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -173,51 +173,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
-dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
- "memoffset",
- "once_cell",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
-dependencies = [
- "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -258,9 +213,19 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+
+[[package]]
+name = "fast_image_resize"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503fb57c3671803f4b1f9347764742bd692cb1941f38157de538a79b5fa8385b"
+dependencies = [
+ "num-traits",
+ "thiserror",
+]
 
 [[package]]
 name = "flate2"
@@ -294,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a7187e78088aead22ceedeee99779455b23fc231fe13ec443f99bb71694e5b"
+checksum = "3edd93c6756b4dfaf2709eafcc345ba2636565295c198a9cfbf75fa5e3e00b06"
 dependencies = [
  "color_quant",
  "weezl",
@@ -380,9 +345,6 @@ name = "jpeg-decoder"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9478aa10f73e7528198d75109c8be5cd7d15fb530238040148d5f9a22d4c5b3b"
-dependencies = [
- "rayon",
-]
 
 [[package]]
 name = "lazy_static"
@@ -540,16 +502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "num_threads"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,40 +646,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
-dependencies = [
- "autocfg",
- "crossbeam-deque",
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
- "num_cpus",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
@@ -771,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc88c725d61fc6c3132893370cac4a0200e3fedf5da8331c570664b1987f5ca2"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -808,6 +730,7 @@ dependencies = [
  "bincode",
  "clap",
  "clap_complete",
+ "fast_image_resize",
  "fork",
  "image",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ strip = false
 
 [dependencies]
 smithay-client-toolkit = { version = "0.16", default-features = false, features = ["calloop"] }
-image = { version = "0.24", default-features = false, features = [ "gif", "jpeg", "jpeg_rayon",
-                                       "png", "pnm", "tga", "tiff", "webp", "bmp", "farbfeld"]}
+image = { version = "0.24", default-features = false, features = [ "gif", "jpeg", "png", "pnm",
+													 "tga", "tiff", "webp", "bmp", "farbfeld"]}
 log = { version = "0.4", features = ["max_level_debug", "release_max_level_info"] }
 simplelog = "0.12"
 fork = "0.1"
@@ -28,6 +28,7 @@ lzzzz = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
 bincode = "1.3"
 lazy_static = "1.4"
+fast_image_resize = "0.9"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,9 +40,9 @@ fn from_hex(hex: &str) -> Result<[u8; 3], String> {
 #[derive(Serialize, Deserialize)]
 pub enum Filter {
     Nearest,
-    Triangle,
+    Bilinear,
     CatmullRom,
-    Gaussian,
+    Mitchell,
     Lanczos3,
 }
 
@@ -52,9 +52,9 @@ impl std::str::FromStr for Filter {
     fn from_str(s: &str) -> Result<Self, String> {
         match s {
             "Nearest" => Ok(Self::Nearest),
-            "Triangle" => Ok(Self::Triangle),
+            "Bilinear" => Ok(Self::Bilinear),
             "CatmullRom" => Ok(Self::CatmullRom),
-            "Gaussian" => Ok(Self::Gaussian),
+            "Mitchell" => Ok(Self::Mitchell),
             "Lanczos3" => Ok(Self::Lanczos3),
             _ => Err(format!("unrecognized filter: {}", s)),
         }
@@ -134,7 +134,7 @@ pub struct Img {
     ///
     ///Available options are:
     ///
-    ///Nearest | Triangle | CatmullRom | Gaussian | Lanczos3
+    ///Nearest | Bilinear | CatmullRom | Mitchell | Lanczos3
     ///
     ///These are offered by the image crate (https://crates.io/crates/image). 'Nearest' is
     ///what I recommend for pixel art stuff, and ONLY for pixel art stuff. It is also the

--- a/src/communication.rs
+++ b/src/communication.rs
@@ -71,13 +71,13 @@ impl Swww {
 
 impl Filter {
     ///Simply gets the equivalent filter from imageops
-    pub fn get_image_filter(&self) -> image::imageops::FilterType {
+    pub fn get_image_filter(&self) -> fast_image_resize::FilterType {
         match self {
-            Self::Nearest => image::imageops::FilterType::Nearest,
-            Self::Triangle => image::imageops::FilterType::Triangle,
-            Self::CatmullRom => image::imageops::FilterType::CatmullRom,
-            Self::Gaussian => image::imageops::FilterType::Gaussian,
-            Self::Lanczos3 => image::imageops::FilterType::Lanczos3,
+            Self::Nearest => fast_image_resize::FilterType::Box,
+            Self::Bilinear => fast_image_resize::FilterType::Bilinear,
+            Self::CatmullRom => fast_image_resize::FilterType::CatmullRom,
+            Self::Mitchell => fast_image_resize::FilterType::Mitchell,
+            Self::Lanczos3 => fast_image_resize::FilterType::Lanczos3,
         }
     }
 }

--- a/src/daemon/processor/animations.rs
+++ b/src/daemon/processor/animations.rs
@@ -6,7 +6,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-use image::{codecs::gif::GifDecoder, imageops::FilterType, AnimationDecoder};
+use image::{codecs::gif::GifDecoder, AnimationDecoder};
+use fast_image_resize::FilterType;
 use log::debug;
 
 use super::{

--- a/src/daemon/processor/mod.rs
+++ b/src/daemon/processor/mod.rs
@@ -1,4 +1,5 @@
-use image::{self, codecs::gif::GifDecoder, imageops::FilterType, ImageFormat};
+use fast_image_resize::FilterType;
+use image::{self, codecs::gif::GifDecoder, ImageFormat};
 use log::debug;
 
 use smithay_client_toolkit::reexports::calloop::channel::SyncSender;
@@ -180,7 +181,7 @@ fn animation(
     }
 }
 
-fn img_resize(img: image::RgbaImage, dimensions: (u32, u32), _filter: FilterType) -> Box<[u8]> {
+fn img_resize(img: image::RgbaImage, dimensions: (u32, u32), filter: FilterType) -> Box<[u8]> {
     let (width, height) = dimensions;
     debug!("Output dimensions: {:?}", (width, height));
     debug!("Image dimensions:  {:?}", img.dimensions());
@@ -204,9 +205,8 @@ fn img_resize(img: image::RgbaImage, dimensions: (u32, u32), _filter: FilterType
         );
         let mut dst_view = dst.view_mut();
 
-        let mut resizer = fast_image_resize::Resizer::new(
-            fast_image_resize::ResizeAlg::Convolution(fast_image_resize::FilterType::Lanczos3),
-        );
+        let mut resizer =
+            fast_image_resize::Resizer::new(fast_image_resize::ResizeAlg::Convolution(filter));
         resizer.resize(&src.view(), &mut dst_view).unwrap();
 
         alpha_mul_div.divide_alpha_inplace(&mut dst_view).unwrap();

--- a/src/daemon/processor/mod.rs
+++ b/src/daemon/processor/mod.rs
@@ -1,4 +1,4 @@
-use image::{self, codecs::gif::GifDecoder, imageops::FilterType, DynamicImage, ImageFormat};
+use image::{self, codecs::gif::GifDecoder, imageops::FilterType, ImageFormat};
 use log::debug;
 
 use smithay_client_toolkit::reexports::calloop::channel::SyncSender;
@@ -180,15 +180,37 @@ fn animation(
     }
 }
 
-fn img_resize(img: image::RgbaImage, dimensions: (u32, u32), filter: FilterType) -> Box<[u8]> {
+fn img_resize(img: image::RgbaImage, dimensions: (u32, u32), _filter: FilterType) -> Box<[u8]> {
     let (width, height) = dimensions;
     debug!("Output dimensions: {:?}", (width, height));
     debug!("Image dimensions:  {:?}", img.dimensions());
     let mut resized_img = if img.dimensions() != (width, height) {
         debug!("Image dimensions are different from output's. Resizing...");
-        DynamicImage::ImageRgba8(img)
-            .resize_to_fill(width, height, filter)
-            .into_rgba8()
+        let mut src = fast_image_resize::Image::from_vec_u8(
+            std::num::NonZeroU32::new(img.dimensions().0).unwrap(),
+            std::num::NonZeroU32::new(img.dimensions().1).unwrap(),
+            img.into_raw(),
+            fast_image_resize::PixelType::U8x4,
+        )
+        .unwrap();
+        let alpha_mul_div = fast_image_resize::MulDiv::default();
+        alpha_mul_div
+            .multiply_alpha_inplace(&mut src.view_mut())
+            .unwrap();
+        let mut dst = fast_image_resize::Image::new(
+            std::num::NonZeroU32::new(width).unwrap(),
+            std::num::NonZeroU32::new(height).unwrap(),
+            fast_image_resize::PixelType::U8x4,
+        );
+        let mut dst_view = dst.view_mut();
+
+        let mut resizer = fast_image_resize::Resizer::new(
+            fast_image_resize::ResizeAlg::Convolution(fast_image_resize::FilterType::Lanczos3),
+        );
+        resizer.resize(&src.view(), &mut dst_view).unwrap();
+
+        alpha_mul_div.divide_alpha_inplace(&mut dst_view).unwrap();
+        image::RgbaImage::from_vec(width, height, dst.into_vec()).unwrap()
     } else {
         img
     };

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -111,7 +111,7 @@ fn sending_img_to_monitor_that_does_not_exist() {
 }
 
 fn sending_imgs_with_filter() {
-    for filter in ["Nearest", "Triangle", "CatmullRom", "Gaussian", "Lanczos3"] {
+    for filter in ["Nearest", "Bilinear", "CatmullRom", "Mitchell", "Lanczos3"] {
         cmd()
             .arg("img")
             .arg(TEST_IMGS[0])


### PR DESCRIPTION
Resizing with fast_image_resize is fast enough that we can resize the images without lagging the initial animation.