### PR TITLE
Fix deadlock when sending images quickly

### DIFF
--- a/src/daemon/processor/mod.rs
+++ b/src/daemon/processor/mod.rs
@@ -98,7 +98,7 @@ impl ProcessorRequest {
 
 pub struct Processor {
     frame_sender: SyncSender<(Vec<String>, ReadiedPack)>,
-    anim_stoppers: Vec<mpsc::SyncSender<Vec<String>>>,
+    anim_stoppers: Vec<mpsc::Sender<Vec<String>>>,
 }
 
 impl Processor {
@@ -140,7 +140,7 @@ impl Processor {
 
     fn transition(&mut self, request: ProcessorRequest, new_img: Box<[u8]>) {
         let sender = self.frame_sender.clone();
-        let (stopper, stop_recv) = mpsc::sync_channel(1);
+        let (stopper, stop_recv) = mpsc::channel();
         self.anim_stoppers.push(stopper);
         if let Err(e) = thread::Builder::new()
             .name("animator".to_string()) //Name our threads  for better log messages


### PR DESCRIPTION
The problem was that we were using SyncSender to stop the animations.

The we use a syncronous channel for sending the frames from the
animation threads in order to ensure old threads that will terminate
soon and new ones don't overlap when sending their frames. However, this
does block the animation threads when they are sending messages.

Because we were also using a syncronous channel to stop the animations,
it was possible that the animation thread was blocked trying to send in
a frame, while the main thread was blocked trying to send in the stop
message.

This fixes that problem by transforming anim_stoppers into a vector of
async Senders.