### PR TITLE
flags to set transition center and speed step

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -244,6 +244,9 @@ pub struct Img {
 
     #[clap(long, env = "SWW_TRANSITION_CORDS_Y", default_value = "0")]
     pub transition_cord_y: usize,
+
+    #[clap(long, env = "SWW_TRANSITION_SPEED_STEP",default_value = "0")]
+    pub transition_speed_step: usize,
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -239,21 +239,21 @@ pub struct Img {
     #[clap(long, env = "SWWW_TRANSITION_FPS", default_value = "30")]
     pub transition_fps: u8,
 
-    ///X cordinate to use as center for the transition
+    ///X coordinate to use as center for the transition
     ///
-    ///Note only wokrs with the `from` transition
-    #[clap(long, env = "SWW_TRANSITION_CORDS_X", default_value = "0")]
-    pub transition_cord_x: usize,
+    ///Note that it only works with the `from` transition
+    #[clap(long, env = "SWW_TRANSITION_CENTER_X", default_value = "0")]
+    pub transition_center_x: usize,
 
-    ///Y cordinate to use as center for the transition
+    ///Y coordinate to use as center for the transition
     ///
-    ///Note only works with the `from` transition
-    #[clap(long, env = "SWW_TRANSITION_CORDS_Y", default_value = "0")]
-    pub transition_cord_y: usize,
+    ///Note that it only works with the `from` transition
+    #[clap(long, env = "SWW_TRANSITION_CENTER_Y", default_value = "0")]
+    pub transition_center_y: usize,
 
     ///value to increase the total speed by every frame
     ///
-    ///Note only works with center|any|outer|from|random transitions
+    ///Note that it only works with center|any|outer|from|random transitions
     #[clap(long, env = "SWW_TRANSITION_SPEED_STEP",default_value = "0")]
     pub transition_speed_step: usize,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -239,12 +239,22 @@ pub struct Img {
     #[clap(long, env = "SWWW_TRANSITION_FPS", default_value = "30")]
     pub transition_fps: u8,
 
+    ///X cordinate to use as center for the transition
+    ///
+    ///this is only used with the `from` transition
+    ///
     #[clap(long, env = "SWW_TRANSITION_CORDS_X", default_value = "0")]
     pub transition_cord_x: usize,
 
+    ///Y cordinate to use as center for the transition
+    ///
+    ///only works with the `from` transition
     #[clap(long, env = "SWW_TRANSITION_CORDS_Y", default_value = "0")]
     pub transition_cord_y: usize,
 
+    ///value to increase the total speed by every frame
+    ///
+    ///only works with center|any|outer|from|random transitions
     #[clap(long, env = "SWW_TRANSITION_SPEED_STEP",default_value = "0")]
     pub transition_speed_step: usize,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -248,13 +248,13 @@ pub struct Img {
 
     ///Y cordinate to use as center for the transition
     ///
-    ///only works with the `from` transition
+    ///Note only works with the `from` transition
     #[clap(long, env = "SWW_TRANSITION_CORDS_Y", default_value = "0")]
     pub transition_cord_y: usize,
 
     ///value to increase the total speed by every frame
     ///
-    ///only works with center|any|outer|from|random transitions
+    ///Note only works with center|any|outer|from|random transitions
     #[clap(long, env = "SWW_TRANSITION_SPEED_STEP",default_value = "0")]
     pub transition_speed_step: usize,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,6 +74,7 @@ pub enum TransitionType {
     Outer,
     Any,
     Random,
+    From,
 }
 
 impl std::str::FromStr for TransitionType {
@@ -90,8 +91,9 @@ impl std::str::FromStr for TransitionType {
             "outer" => Ok(Self::Outer),
             "any" => Ok(Self::Any),
             "random" => Ok(Self::Random),
+            "from" => Ok(Self::From),
             _ => Err("unrecognized transition type. Valid transitions are:\
-                     simple | lest | right | top | bottom | center | outer | random\
+                     [ simple | left | right | top | bottom | center | outer | random | from ]\
                      see swww img --help for more details"),
         }
     }
@@ -236,6 +238,12 @@ pub struct Img {
     ///approach the new image every frame.
     #[clap(long, env = "SWWW_TRANSITION_FPS", default_value = "30")]
     pub transition_fps: u8,
+
+    #[clap(long, env = "SWW_TRANSITION_CORDS_X", default_value = "0")]
+    pub transition_cord_x: usize,
+
+    #[clap(long, env = "SWW_TRANSITION_CORDS_Y", default_value = "0")]
+    pub transition_cord_y: usize,
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -241,8 +241,7 @@ pub struct Img {
 
     ///X cordinate to use as center for the transition
     ///
-    ///this is only used with the `from` transition
-    ///
+    ///Note only wokrs with the `from` transition
     #[clap(long, env = "SWW_TRANSITION_CORDS_X", default_value = "0")]
     pub transition_cord_x: usize,
 

--- a/src/daemon/processor/animations.rs
+++ b/src/daemon/processor/animations.rs
@@ -66,7 +66,7 @@ impl Transition {
         outputs: &mut Vec<String>,
         sender: &SyncSender<(Vec<String>, ReadiedPack)>,
         stop_recv: &mpsc::Receiver<Vec<String>>,
-        cords: (usize, usize),
+        pos: (usize, usize),
         speed_step: usize
     ) -> bool {
         debug!("Starting transition");
@@ -80,7 +80,7 @@ impl Transition {
             TransitionType::Outer => self.outer(new_img, outputs, sender, stop_recv,speed_step),
             TransitionType::Any => self.any(new_img, outputs, sender, stop_recv,speed_step),
             TransitionType::Random => self.random(new_img, outputs, sender, stop_recv,speed_step),
-            TransitionType::From => self.from(new_img, outputs, sender, stop_recv, cords,speed_step),
+            TransitionType::From => self.from(new_img, outputs, sender, stop_recv, pos,speed_step),
         }
     }
 
@@ -356,15 +356,15 @@ impl Transition {
         outputs: &mut Vec<String>,
         sender: &SyncSender<(Vec<String>, ReadiedPack)>,
         stop_recv: &mpsc::Receiver<Vec<String>>,
-        cords: (usize, usize),
+        pos: (usize, usize),
         speed_step: usize
     ) -> bool {
         let fps = self.fps;
         let mut speed = self.speed as usize;
         let (width, height) = (self.dimensions.0 as usize, self.dimensions.1 as usize);
         let (center_x, center_y) = (
-            cords.0.min(width - 1),
-            cords.1.min(height - 1),
+            pos.0.min(width - 1),
+            pos.1.min(height - 1),
         );
         let mut dist_center = 0;
         let mut now = Instant::now();
@@ -513,7 +513,7 @@ mod tests {
 
             let handle = {
                 let new_img = new_img.clone();
-                std::thread::spawn(move || t.execute(&new_img, &mut dummies, &fr_send, &stop_recv, None))
+                std::thread::spawn(move || t.execute(&new_img, &mut dummies, &fr_send, &stop_recv, (0,0),0))
             };
 
             while let Ok((_, i)) = fr_recv.recv() {

--- a/src/daemon/processor/mod.rs
+++ b/src/daemon/processor/mod.rs
@@ -42,7 +42,7 @@ pub struct ProcessorRequest {
     filter: FilterType,
     step: u8,
     fps: Duration,
-    cords: (usize, usize),
+    pos: (usize, usize),
     speed_step: usize,
 }
 
@@ -58,7 +58,7 @@ impl ProcessorRequest {
             filter: img.filter.get_image_filter(),
             step: img.transition_step,
             fps: Duration::from_nanos(1_000_000_000 / img.transition_fps as u64),
-            cords: (img.transition_cord_x,img.transition_cord_y),
+            pos: (img.transition_center_x,img.transition_center_y),
             speed_step: img.transition_speed_step
         }
     }
@@ -96,7 +96,7 @@ impl ProcessorRequest {
                 None
             }
         };
-        (self.outputs, transition, animation,self.cords,self.speed_step)
+        (self.outputs, transition, animation,self.pos,self.speed_step)
     }
 }
 
@@ -150,8 +150,8 @@ impl Processor {
             .name("animator".to_string()) //Name our threads  for better log messages
             .stack_size(TSTACK_SIZE) //the default of 2MB is way too overkill for this
             .spawn(move || {
-                let (mut out, transition, gif,cords,speed_step) = request.split();
-                if transition.execute(&new_img, &mut out, &sender, &stop_recv, cords,speed_step) {
+                let (mut out, transition, gif,pos,speed_step) = request.split();
+                if transition.execute(&new_img, &mut out, &sender, &stop_recv, pos,speed_step) {
                     if let Some(gif) = gif {
                         animation(gif, new_img, out, sender, stop_recv);
                     }

--- a/src/daemon/processor/mod.rs
+++ b/src/daemon/processor/mod.rs
@@ -42,6 +42,7 @@ pub struct ProcessorRequest {
     filter: FilterType,
     step: u8,
     fps: Duration,
+    cords: Option<(usize, usize)>,
 }
 
 impl ProcessorRequest {
@@ -56,6 +57,7 @@ impl ProcessorRequest {
             filter: img.filter.get_image_filter(),
             step: img.transition_step,
             fps: Duration::from_nanos(1_000_000_000 / img.transition_fps as u64),
+            cords: Some((img.transition_cord_x,img.transition_cord_y)),
         }
     }
 
@@ -67,7 +69,7 @@ impl ProcessorRequest {
         self.dimensions
     }
 
-    fn split(self) -> (Vec<String>, Transition, Option<GifProcessor>) {
+    fn split(self) -> (Vec<String>, Transition, Option<GifProcessor>,Option<(usize,usize)>){
         let transition = Transition::new(
             self.old_img,
             self.dimensions,
@@ -92,7 +94,7 @@ impl ProcessorRequest {
                 None
             }
         };
-        (self.outputs, transition, animation)
+        (self.outputs, transition, animation,self.cords)
     }
 }
 
@@ -146,8 +148,8 @@ impl Processor {
             .name("animator".to_string()) //Name our threads  for better log messages
             .stack_size(TSTACK_SIZE) //the default of 2MB is way too overkill for this
             .spawn(move || {
-                let (mut out, transition, gif) = request.split();
-                if transition.execute(&new_img, &mut out, &sender, &stop_recv) {
+                let (mut out, transition, gif,cords) = request.split();
+                if transition.execute(&new_img, &mut out, &sender, &stop_recv, cords) {
                     if let Some(gif) = gif {
                         animation(gif, new_img, out, sender, stop_recv);
                     }


### PR DESCRIPTION
added ability to change center position of transition(like the `any` transition but with specified position) 
and a speed_step flag so animations dont feel so linear

flags:
`--transition-type from`
`--transition-speed-step {int}`


needs transition type to be `from`
> `--transition-center-x {x cordinate}`
> `--transition-center-y {y cordinate}`


https://user-images.githubusercontent.com/77581181/191263774-d29ca7da-e346-4651-add2-fdddaf153c13.mp4