### PR TITLE
'grow' transition and 'outer' transition with ability to set transition position

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,6 +75,7 @@ pub enum TransitionType {
     Any,
     Random,
     Wipe,
+    Grow,
 }
 
 impl std::str::FromStr for TransitionType {
@@ -87,13 +88,14 @@ impl std::str::FromStr for TransitionType {
             "right" => Ok(Self::Right),
             "top" => Ok(Self::Top),
             "bottom" => Ok(Self::Bottom),
+            "wipe" => Ok(Self::Wipe),
+            "grow" => Ok(Self::Grow),
             "center" => Ok(Self::Center),
             "outer" => Ok(Self::Outer),
             "any" => Ok(Self::Any),
             "random" => Ok(Self::Random),
-            "wipe" => Ok(Self::Wipe),
             _ => Err("unrecognized transition type. Valid transitions are:\
-                     simple | lest | right | top | bottom | center | outer | random | wipe\
+                     simple | lest | right | top | bottom | wipe | grow | center | outer | random\
                      see swww img --help for more details"),
         }
     }
@@ -188,17 +190,21 @@ pub struct Img {
     ///
     ///Possible transitions are:
     ///
-    ///simple | left | right | top | bottom | wipe | center | outer | any | random
+    ///simple | left | right | top | bottom | wipe | grow | center | any | outer | random
     ///
     ///The 'left', 'right', 'top' and 'bottom' options make the transition happen from that
     ///position to its oposite in the screen.
     ///
     ///'wipe' is simillar to 'left' but allows you to specify the angle for transition (with the --transition-angle flag).
-    /// 
-    ///'center' causes a transition from the center to the edges of the screen, while 'outer' is
-    ///the oposite of that.
     ///
-    ///'any' is like 'center', but selects a random spot to start the transition from
+    ///'grow' causes a growing circle to transition across the screen and allows changing the circle's center\
+    /// position (with --transition-pos flag).
+    ///
+    ///'center' an alias to 'grow' with position set to center of screen.
+    ///
+    ///'any' an alias to 'grow' with position set to a random point on screen.
+    ///
+    ///'outer' same as grow but the circle shrinks instead of growing.
     ///
     ///Finally, 'random' will select a transition effect at random
     #[arg(short, long, env = "SWWW_TRANSITION", default_value = "simple")]
@@ -245,6 +251,16 @@ pub struct Img {
     ///Note that the angle is in degrees, where '0' is right to left and '90' is top to bottom, and '270' bottom to top
     #[arg(long, env = "SWWW_TRANSITION_ANGLE", default_value = "0")]
     pub transition_angle: f64,
+
+    ///This is only used for the 'grow','outer' transitions. It controls the center of circle (default is 'center').
+    ///
+    ///position values can be given in the format of '<x_pos>,<y_pos>', for example '700,0' is 700px from left and 0px from bottom
+    ///x_pos and y_pos can also be percentages, which are parsed according to screen size, for example '50%,50%' for center
+    ///
+    ///the value can also be an alias which will set the position accordingly):
+    /// 'center' | 'top' | 'left' | 'right' | 'bottom' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+    #[arg(long, env = "SWWW_TRANSITION_POS", default_value = "center")]
+    pub transition_pos: String,
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -316,36 +316,37 @@ fn parse_coords(raw: &str) -> Result<(f32,f32), String> {
         x = coords[0];
         y = coords[1];
     }
-    let parsed_x: f32;
-    let parsed_y: f32;
+    
+    
 
     //parse x coord
-    match x.parse::<f32>() {
+    let parsed_x = match x.parse::<f32>() {
         Ok(x) => {
-            if x > 1.0 || x < 0.0{
+            if !(0.0..=1.0).contains(&x){
                 return Err(format!(
                     "x coord not in range [0,1.0]: {}",
                     x
                 ))
             }
-            parsed_x = x
+            x
         },
         Err(_) => return Err(format!("Invalid x coord: {}", x)),
-    }
+    };
 
     //parse y coord
-    match y.parse::<f32>() {
+    let parsed_y = match y.parse::<f32>() {
         Ok(y) => {
-            if y > 1.0 || y < 0.0{
+            if !(0.0..=1.0).contains(&y){
                 return Err(format!(
                     "y coord not in range [0,1.0]: {}",
                     y
                 ))
             }
-            parsed_y = y
+            y
         },
         Err(_) => return Err(format!("Invalid y coord: {}", y)),
-    }
+    };
+    
     Ok((parsed_x, parsed_y))
 }
 

--- a/src/daemon/processor/animations.rs
+++ b/src/daemon/processor/animations.rs
@@ -273,11 +273,7 @@ impl Transition {
             let x = pix_x - center.0 as f64;
             let y = pix_y - center.1 as f64;
             let res = x * a + y * b + offset;
-            if res >= radius.powf(2.0) {
-                true
-            } else {
-                false
-            }
+            res >= radius.powf(2.0)
         };
         loop {
             let transition_img =

--- a/src/daemon/processor/animations.rs
+++ b/src/daemon/processor/animations.rs
@@ -39,6 +39,7 @@ pub struct Transition {
     step: u8,
     fps: Duration,
     angle: f64,
+    pos: (u32, u32),
 }
 
 /// All transitions return whether or not they completed
@@ -51,6 +52,7 @@ impl Transition {
         step: u8,
         fps: Duration,
         angle: f64,
+        pos: (u32, u32),
     ) -> Self {
         Transition {
             old_img,
@@ -60,6 +62,7 @@ impl Transition {
             step,
             fps,
             angle,
+            pos,
         }
     }
 
@@ -77,11 +80,12 @@ impl Transition {
             TransitionType::Right => self.right(new_img, outputs, sender, stop_recv),
             TransitionType::Top => self.top(new_img, outputs, sender, stop_recv),
             TransitionType::Bottom => self.bottom(new_img, outputs, sender, stop_recv),
-            TransitionType::Center => self.center(new_img, outputs, sender, stop_recv),
-            TransitionType::Outer => self.outer(new_img, outputs, sender, stop_recv),
-            TransitionType::Any => self.any(new_img, outputs, sender, stop_recv),
             TransitionType::Random => self.random(new_img, outputs, sender, stop_recv),
             TransitionType::Wipe => self.wipe(new_img, outputs, sender, stop_recv),
+            TransitionType::Grow => self.grow(new_img, outputs, sender, stop_recv),
+            TransitionType::Outer => self.outer(new_img, outputs, sender, stop_recv),
+            TransitionType::Center => false,
+            TransitionType::Any => false,
         }
     }
 
@@ -99,9 +103,6 @@ impl Transition {
             2 => self.right(new_img, outputs, sender, stop_recv),
             3 => self.top(new_img, outputs, sender, stop_recv),
             4 => self.bottom(new_img, outputs, sender, stop_recv),
-            5 => self.center(new_img, outputs, sender, stop_recv),
-            6 => self.outer(new_img, outputs, sender, stop_recv),
-            7 => self.any(new_img, outputs, sender, stop_recv),
             _ => unreachable!(),
         }
     }
@@ -292,7 +293,7 @@ impl Transition {
         }
     }
 
-    fn center(
+    fn grow(
         mut self,
         new_img: &[u8],
         outputs: &mut Vec<String>,
@@ -302,7 +303,7 @@ impl Transition {
         let fps = self.fps;
         let speed = self.speed as usize;
         let (width, height) = (self.dimensions.0 as usize, self.dimensions.1 as usize);
-        let (center_x, center_y) = (width / 2, height / 2);
+        let (center_x, center_y) = self.pos;
         let mut dist_center = 0;
         let mut now = Instant::now();
         loop {
@@ -310,8 +311,8 @@ impl Transition {
                 ReadiedPack::new(&mut self.old_img, new_img, |old_pix, new_pix, i| {
                     let pix_x = i % width;
                     let pix_y = height - i / width;
-                    let diff_x = pix_x.abs_diff(center_x);
-                    let diff_y = pix_y.abs_diff(center_y);
+                    let diff_x = pix_x.abs_diff(center_x as usize);
+                    let diff_y = pix_y.abs_diff(center_y as usize);
                     let pix_center_dist = diff_x * diff_x + diff_y * diff_y;
                     if pix_center_dist <= dist_center * dist_center {
                         let step = self
@@ -336,16 +337,26 @@ impl Transition {
         let fps = self.fps;
         let speed = self.speed as usize;
         let (width, height) = (self.dimensions.0 as usize, self.dimensions.1 as usize);
-        let (center_x, center_y) = (width / 2, height / 2);
-        let mut dist_center = ((center_x * center_x + center_y * center_y) as f64).sqrt() as usize;
+        let (center_x, center_y) = self.pos;
+        let mut dist_center = {
+            let mut x = center_x as usize;
+            let mut y = center_y as usize;
+            if x < width/2 {
+                x = width - 1 - x;
+            }
+            if y < height/2{
+                y = height - 1 - y;
+            }
+            ((x.pow(2)+y.pow(2)) as f64).sqrt() as usize
+        };
         let mut now = Instant::now();
         loop {
             let transition_img =
                 ReadiedPack::new(&mut self.old_img, new_img, |old_pix, new_pix, i| {
                     let pix_x = i % width;
                     let pix_y = height - i / width;
-                    let diff_x = pix_x.abs_diff(center_x);
-                    let diff_y = pix_y.abs_diff(center_y);
+                    let diff_x = pix_x.abs_diff(center_x as usize);
+                    let diff_y = pix_y.abs_diff(center_y as usize);
                     let pix_center_dist = diff_x * diff_x + diff_y * diff_y;
                     if pix_center_dist >= dist_center * dist_center {
                         let step =
@@ -360,43 +371,6 @@ impl Transition {
             } else {
                 dist_center = 0;
             }
-        }
-    }
-
-    fn any(
-        mut self,
-        new_img: &[u8],
-        outputs: &mut Vec<String>,
-        sender: &SyncSender<(Vec<String>, ReadiedPack)>,
-        stop_recv: &mpsc::Receiver<Vec<String>>,
-    ) -> bool {
-        let fps = self.fps;
-        let speed = self.speed as usize;
-        let (width, height) = (self.dimensions.0 as usize, self.dimensions.1 as usize);
-        let (center_x, center_y) = (
-            rand::random::<usize>() % width,
-            rand::random::<usize>() % height,
-        );
-        let mut dist_center = 0;
-        let mut now = Instant::now();
-        loop {
-            let transition_img =
-                ReadiedPack::new(&mut self.old_img, new_img, |old_pix, new_pix, i| {
-                    let pix_x = i % width;
-                    let pix_y = height - i / width;
-                    let diff_x = pix_x.abs_diff(center_x);
-                    let diff_y = pix_y.abs_diff(center_y);
-                    let pix_center_dist = diff_x * diff_x + diff_y * diff_y;
-                    if pix_center_dist <= dist_center * dist_center {
-                        let step = self
-                            .step
-                            .saturating_add(((dist_center * dist_center) - pix_center_dist) as u8);
-                        change_cols(step, old_pix, *new_pix);
-                    }
-                });
-            send_transition_frame!(transition_img, outputs, now, fps, sender, stop_recv);
-            now = Instant::now();
-            dist_center += speed;
         }
     }
 }
@@ -494,6 +468,7 @@ mod tests {
             100,
             Duration::from_nanos(1),
             0.0,
+            (0, 0),
         )
     }
 

--- a/src/daemon/processor/animations.rs
+++ b/src/daemon/processor/animations.rs
@@ -341,13 +341,13 @@ impl Transition {
         let mut dist_center = {
             let mut x = center_x as usize;
             let mut y = center_y as usize;
-            if x < width/2 {
+            if x < width / 2 {
                 x = width - 1 - x;
             }
-            if y < height/2{
+            if y < height / 2 {
                 y = height - 1 - y;
             }
-            ((x.pow(2)+y.pow(2)) as f64).sqrt() as usize
+            ((x.pow(2) + y.pow(2)) as f64).sqrt() as usize
         };
         let mut now = Instant::now();
         loop {

--- a/src/daemon/processor/mod.rs
+++ b/src/daemon/processor/mod.rs
@@ -43,21 +43,39 @@ pub struct ProcessorRequest {
     step: u8,
     fps: Duration,
     angle: f64,
+    pos: (u32, u32),
 }
 
 impl ProcessorRequest {
     pub fn new(info: &BgInfo, old_img: Box<[u8]>, img: &Img) -> Self {
+        let dimensions = info.real_dim();
+        let mut pos = parse_coords(img.transition_pos.clone(), dimensions);
+        let transition_type: TransitionType = match img.transition_type {
+            TransitionType::Center => {
+                pos = (dimensions.0 / 2, dimensions.1 / 2);
+                TransitionType::Grow
+            }
+            TransitionType::Any => {
+                pos = (
+                    rand::random::<u32>() % dimensions.0,
+                    rand::random::<u32>() % dimensions.1,
+                );
+                TransitionType::Grow
+            }
+            _ => img.transition_type.clone(),
+        };
         Self {
             outputs: vec![info.name.to_string()],
-            dimensions: info.real_dim(),
+            dimensions: dimensions,
             old_img,
             path: img.path.clone(),
-            transition_type: img.transition_type.clone(),
+            transition_type: transition_type,
             speed: img.transition_speed,
             filter: img.filter.get_image_filter(),
             step: img.transition_step,
             fps: Duration::from_nanos(1_000_000_000 / img.transition_fps as u64),
             angle: img.transition_angle,
+            pos: pos,
         }
     }
 
@@ -78,6 +96,7 @@ impl ProcessorRequest {
             self.step,
             self.fps,
             self.angle,
+            self.pos,
         );
         let img = image::io::Reader::open(&self.path);
         let animation = {
@@ -308,4 +327,103 @@ fn send_frame(
         Ok(()) => false,
         Err(_) => true,
     }
+}
+
+// parses percentages and numbers in format of "<coord1>,<coord2>"
+fn parse_coords(raw: String, dimensions: (u32, u32)) -> (u32, u32) {
+    let coords = raw.split(',').map(|s| s.trim()).collect::<Vec<&str>>();
+    let x: &str;
+    let y: &str;
+    if coords.len() != 2 {
+        match coords[0] {
+            "center" => {
+                x = "50%";
+                y = "50%";
+            }
+            "top" => {
+                x = "50%";
+                y = "100%";
+            }
+            "bottom" => {
+                x = "50%";
+                y = "0";
+            }
+            "left" => {
+                x = "0";
+                y = "50%";
+            }
+            "right" => {
+                x = "100%";
+                y = "50%";
+            }
+            "top-left" => {
+                x = "0";
+                y = "100%";
+            }
+            "top-right" => {
+                x = "100%";
+                y = "100%";
+            }
+            "bottom-left" => {
+                x = "0";
+                y = "0";
+            }
+            "bottom-right" => {
+                x = "100%";
+                y = "0";
+            }
+            _ => {
+                debug!(
+                    "Invalid position keyword, using center as fallback: {}",
+                    raw
+                );
+                x = "50%";
+                y = "50%";
+            }
+        }
+    } else {
+        x = coords[0];
+        y = coords[1];
+    }
+    let mut parsed_x: u32;
+    let mut parsed_y: u32;
+
+    //parse x coord
+    match x.parse::<u32>() {
+        Ok(x) => parsed_x = x,
+        Err(_) => {
+            debug!("Invalid x coord, trying to parse as percentage: {}", x);
+            if x.ends_with("%") {
+                let x = x.trim_end_matches("%");
+                match x.parse::<u32>() {
+                    Ok(x) => parsed_x = x,
+                    Err(_) => parsed_x = 0,
+                }
+                parsed_x = parsed_x * dimensions.0 / 100;
+            } else {
+                debug!("Invalid x coord, using 0 as fallback: {}", x);
+                parsed_x = 0;
+            }
+        }
+    }
+
+    //parse y coord
+    match y.parse::<u32>() {
+        Ok(y) => parsed_y = y,
+        Err(_) => {
+            debug!("Invalid y coord, trying to parse as percentage: {}", y);
+            if y.ends_with("%") {
+                let y = y.trim_end_matches("%");
+                match y.parse::<u32>() {
+                    Ok(y) => parsed_y = y,
+                    Err(_) => parsed_y = 0,
+                }
+                parsed_y = parsed_y * dimensions.1 / 100;
+            } else {
+                debug!("Invalid y coord, using 0 as fallback: {}", y);
+                parsed_y = 0;
+            }
+        }
+    }
+    (parsed_x, parsed_y)
 }

--- a/src/daemon/processor/mod.rs
+++ b/src/daemon/processor/mod.rs
@@ -43,39 +43,27 @@ pub struct ProcessorRequest {
     step: u8,
     fps: Duration,
     angle: f64,
-    pos: (u32, u32),
+    pos: (f32, f32),
 }
 
 impl ProcessorRequest {
     pub fn new(info: &BgInfo, old_img: Box<[u8]>, img: &Img) -> Self {
         let dimensions = info.real_dim();
-        let mut pos = parse_coords(img.transition_pos.clone(), dimensions);
-        let transition_type: TransitionType = match img.transition_type {
-            TransitionType::Center => {
-                pos = (dimensions.0 / 2, dimensions.1 / 2);
-                TransitionType::Grow
-            }
-            TransitionType::Any => {
-                pos = (
-                    rand::random::<u32>() % dimensions.0,
-                    rand::random::<u32>() % dimensions.1,
-                );
-                TransitionType::Grow
-            }
-            _ => img.transition_type.clone(),
-        };
+        let raw_pos = img.transition_pos;
+        let pos = (raw_pos.0 * dimensions.0 as f32, raw_pos.1 * dimensions.1 as f32);
+        let transition_type: TransitionType = img.transition_type.clone();
         Self {
             outputs: vec![info.name.to_string()],
-            dimensions: dimensions,
+            dimensions,
             old_img,
             path: img.path.clone(),
-            transition_type: transition_type,
+            transition_type,
             speed: img.transition_speed,
             filter: img.filter.get_image_filter(),
             step: img.transition_step,
             fps: Duration::from_nanos(1_000_000_000 / img.transition_fps as u64),
             angle: img.transition_angle,
-            pos: pos,
+            pos,
         }
     }
 
@@ -329,101 +317,3 @@ fn send_frame(
     }
 }
 
-// parses percentages and numbers in format of "<coord1>,<coord2>"
-fn parse_coords(raw: String, dimensions: (u32, u32)) -> (u32, u32) {
-    let coords = raw.split(',').map(|s| s.trim()).collect::<Vec<&str>>();
-    let x: &str;
-    let y: &str;
-    if coords.len() != 2 {
-        match coords[0] {
-            "center" => {
-                x = "50%";
-                y = "50%";
-            }
-            "top" => {
-                x = "50%";
-                y = "100%";
-            }
-            "bottom" => {
-                x = "50%";
-                y = "0";
-            }
-            "left" => {
-                x = "0";
-                y = "50%";
-            }
-            "right" => {
-                x = "100%";
-                y = "50%";
-            }
-            "top-left" => {
-                x = "0";
-                y = "100%";
-            }
-            "top-right" => {
-                x = "100%";
-                y = "100%";
-            }
-            "bottom-left" => {
-                x = "0";
-                y = "0";
-            }
-            "bottom-right" => {
-                x = "100%";
-                y = "0";
-            }
-            _ => {
-                debug!(
-                    "Invalid position keyword, using center as fallback: {}",
-                    raw
-                );
-                x = "50%";
-                y = "50%";
-            }
-        }
-    } else {
-        x = coords[0];
-        y = coords[1];
-    }
-    let mut parsed_x: u32;
-    let mut parsed_y: u32;
-
-    //parse x coord
-    match x.parse::<u32>() {
-        Ok(x) => parsed_x = x,
-        Err(_) => {
-            debug!("Invalid x coord, trying to parse as percentage: {}", x);
-            if x.ends_with("%") {
-                let x = x.trim_end_matches("%");
-                match x.parse::<u32>() {
-                    Ok(x) => parsed_x = x,
-                    Err(_) => parsed_x = 0,
-                }
-                parsed_x = parsed_x * dimensions.0 / 100;
-            } else {
-                debug!("Invalid x coord, using 0 as fallback: {}", x);
-                parsed_x = 0;
-            }
-        }
-    }
-
-    //parse y coord
-    match y.parse::<u32>() {
-        Ok(y) => parsed_y = y,
-        Err(_) => {
-            debug!("Invalid y coord, trying to parse as percentage: {}", y);
-            if y.ends_with("%") {
-                let y = y.trim_end_matches("%");
-                match y.parse::<u32>() {
-                    Ok(y) => parsed_y = y,
-                    Err(_) => parsed_y = 0,
-                }
-                parsed_y = parsed_y * dimensions.1 / 100;
-            } else {
-                debug!("Invalid y coord, using 0 as fallback: {}", y);
-                parsed_y = 0;
-            }
-        }
-    }
-    (parsed_x, parsed_y)
-}


### PR DESCRIPTION
`grow` transition merges `center` and `any` transitions ( `center` and `any` transitions work as aliases now )
and a new `--transition-pos` flag

### changes
+ new `--transition-pos` flag:
  the position for `grow` and `outer` transitions, accepts coords in format `<x_pos>,<y_pos>` 
  the values for x_pos and y_pos can be given as:
   + percentages (floats between 0 and 1.0) like `0.2,0` and `0.8,0.7` 

    you can also use keywords `'center' | 'top' | 'left' | 'right' | 'bottom' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'` as aliases

    for example:
    ```bash
    --transition-pos 0,0.25     # 0 pixels from left and 25% pixels from bottom
    --transition-pos 0.5,0.5     # 50% pixels from left and 50% pixels from bottom
    --transition-pos top-left  # alias to `0,1`
    ```
   ( this flag will be overridden if user uses `center` and `any` transitions )
+ `--transition-type grow` is like `center` but uses `--transition-pos` flag
+ `--transition-type outer` can also use the `--transition-pos` flag
 

a smaller pr, made according to [this](https://github.com/Horus645/swww/pull/36#issuecomment-1263753602) comment