### PR TITLE
change default transition step value

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -219,7 +219,7 @@ pub struct Img {
     ///
     ///Broadly speaking, this is mostly only visible during the 'simple' transition. The other
     ///transitions tend to change more with the 'transition-step' and 'transition-speed' options
-    #[arg(long, env = "SWWW_TRANSITION_STEP", default_value = "10")]
+    #[arg(long, env = "SWWW_TRANSITION_STEP", default_value = "90")]
     pub transition_step: u8,
 
     ///How long the transition takes to complete in seconds.


### PR DESCRIPTION
i feel like rn default transition step is more on the "too smooth" side,

this pr changes it to `90` and it shud be on a nice middle ground.