### PR TITLE
use `with_guessed_format` to detect image type

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,12 @@ fn read_img(path: &Path) -> Result<(RgbaImage, bool), String> {
         Ok(img) => img,
         Err(e) => return Err(format!("failed to open image: {}", e)),
     };
+
+    let imgbuf = match imgbuf.with_guessed_format() {
+        Ok(img) => img,
+        Err(e) => return Err(format!("failed to detect the image's format: {}", e)),
+    };
+
     let is_gif = imgbuf.format() == Some(image::ImageFormat::Gif);
     match imgbuf.decode() {
         Ok(img) => Ok((img.into_rgba8(), is_gif)),


### PR DESCRIPTION
Fixes #74 