### PR TITLE
fix `swww` query not returning correct image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+Fixes:
+  * `swww query` not returing the image being displayed
 
 ### 0.7.0
 

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -504,9 +504,12 @@ fn recv_socket_msg(
 fn get_old_imgs(bgs: &mut RefMut<Vec<Bg>>, imgs: &[(Img, Vec<String>)]) -> Vec<ImgWithDim> {
     let mut v = Vec::with_capacity(imgs.len());
 
-    for (_, outputs) in imgs {
+    for (img, outputs) in imgs {
         if let Some(bg) = bgs.iter_mut().find(|bg| bg.info.name == outputs[0]) {
             v.push((bg.get_current_img().into(), bg.info.real_dim()));
+        }
+        for bg in bgs.iter_mut().filter(|bg| outputs.contains(&bg.info.name)) {
+            bg.info.img = BgImg::Img(img.path.clone());
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,6 +169,10 @@ fn make_img_request(
                 } else {
                     img_resize(img_raw.clone(), *dim, make_filter(&img.filter))?
                 },
+                path: match img.path.canonicalize() {
+                    Ok(p) => p,
+                    Err(e) => return Err(format!("failed no canonicalize image path: {e}")),
+                },
             },
             outputs.to_owned(),
         ));
@@ -195,7 +199,10 @@ fn get_dimensions_and_outputs(
                     continue;
                 }
                 let mut should_add = true;
-                let real_dim = (info.dim.0 * info.scale_factor as u32, info.dim.1 * info.scale_factor as u32);
+                let real_dim = (
+                    info.dim.0 * info.scale_factor as u32,
+                    info.dim.1 * info.scale_factor as u32,
+                );
                 for (i, (dim, img)) in dims.iter().zip(&imgs).enumerate() {
                     if real_dim == *dim && info.img == *img {
                         outputs[i].push(info.name.clone());

--- a/utils/src/communication.rs
+++ b/utils/src/communication.rs
@@ -90,6 +90,7 @@ pub struct Transition {
 
 #[derive(Serialize, Deserialize)]
 pub struct Img {
+    pub path: PathBuf,
     pub img: Vec<u8>,
 }
 


### PR DESCRIPTION
We weren't storing the image path, so `swww query` never returned the current image being displayed.