### PR TITLE
fix reading image from stdin (don't cannonicalize)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Fixes:
   * `swww query` not returing the image being displayed
+  * document `--no_resize` and `--fill_color` options for `swww img`
+  * reading img from stdin (now with a proper integration test to make sure
+  it doesn't happen again) (#42)
 
 ### 0.7.0
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,13 @@ fn make_img_request(
                 },
                 path: match img.path.canonicalize() {
                     Ok(p) => p,
-                    Err(e) => return Err(format!("failed no canonicalize image path: {e}")),
+                    Err(e) => {
+                        if let Some("-") = img.path.to_str() {
+                            PathBuf::from("STDIN")
+                        } else {
+                            return Err(format!("failed no canonicalize image path: {e}"));
+                        }
+                    }
                 },
             },
             outputs.to_owned(),

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -56,6 +56,7 @@ fn main() {
     sending_img_that_does_not_exist();
     sending_imgs_with_filter();
     sending_img_with_filter_that_does_not_exist();
+    sending_img_from_stdin();
     let output = query_outputs();
     sending_img_to_individual_monitors(&output);
     sending_img_to_monitor_that_does_not_exist();
@@ -121,6 +122,17 @@ fn sending_imgs_with_filter() {
             .success();
     }
 }
+
+fn sending_img_from_stdin() {
+    cmd()
+        .arg("img")
+        .arg("-")
+        .pipe_stdin("test_images/test1.jpg")
+        .expect("failed to pipw stdin")
+        .assert()
+        .success();
+}
+
 fn sending_img_with_filter_that_does_not_exist() {
     cmd()
         .arg("img")


### PR DESCRIPTION
We can't cannonicalize the '-' path, so let's not do that. Also added a regression test to avoid this happenning again.

Fixes #42 (again)