### PR TITLE
split outputs with comma

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ fn make_request(args: &Swww) -> Result<Request, String> {
 
 fn split_cmdline_outputs(outputs: &str) -> Vec<String> {
     outputs
-        .split(' ')
+        .split(',')
         .map(|s| s.to_owned())
         .filter(|s| !s.is_empty())
         .collect()


### PR DESCRIPTION
According to the documentation, the '-o' option should take a comma-separated list of outputs, not a space-separated one.