### PR TITLE
Send status update to systemd when daemon has initialized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,6 +1169,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "sd-notify"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "621e3680f3e07db4c9c2c3fb07c6223ab2fab2e54bd3c04c3ae037990f428c32"
+
+[[package]]
 name = "serde"
 version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,6 +1291,7 @@ dependencies = [
  "keyframe",
  "log",
  "rand",
+ "sd-notify",
  "simplelog",
  "smithay-client-toolkit",
  "utils",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -12,6 +12,7 @@ simplelog = "0.12"
 keyframe = "1.1"
 
 utils = { path = "../utils" }
+sd-notify = { version = "0.4.1" }
 
 [dev-dependencies]
 rand = "0.8"

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -425,6 +425,11 @@ fn main_loop(
     }
 
     info!("Initialization succeeded! Starting main loop...");
+    if let Ok(true) = sd_notify::booted() {
+        if let Err(e) = sd_notify::notify(true, &[sd_notify::NotifyState::Ready]) {
+            return Err(e.to_string());
+        }
+    }
     let mut loop_signal = event_loop.get_signal();
     if let Err(e) = event_loop.run(None, &mut loop_signal, |_| {
         {


### PR DESCRIPTION
When running the swww daemon as a systemd service and setting a background image immediately after calling `systemctl --user start swww-daemon` it's possible the command will fail because the daemon isn't fully initialized yet.

Systemd has a mechanism for solving this by having the program send a status update to systemd to let it know when it's done initializing, that way you can wait on the service for the daemon to start and only then set the image. For reference, the relevant [man page](https://www.man7.org/linux/man-pages/man3/sd_notify.3.html).

I'm not sure how many people would benefit from this, so I'd totally understand if you would prefer to put this behind a feature flag or just not merge at all.

Just let me know how you want to proceed, and thank you for making this awesome project!