### PR TITLE
Cache gif animations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,7 +1292,6 @@ dependencies = [
  "log",
  "rand",
  "sd-notify",
- "simplelog",
  "smithay-client-toolkit",
  "utils",
 ]
@@ -1442,6 +1441,7 @@ dependencies = [
  "lzzzz",
  "rand",
  "serde",
+ "simplelog",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,11 +1276,14 @@ name = "swww"
 version = "0.7.3"
 dependencies = [
  "assert_cmd",
+ "bincode",
  "clap 4.2.1",
  "clap_complete",
  "fast_image_resize",
  "image",
+ "log",
  "rand",
+ "serde",
  "utils",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,13 @@ debug = 1
 strip = false
 
 [dependencies]
+bincode = "1.3"
 image = "0.24"
 fast_image_resize = "2.7"
 clap = { version = "4.2", features = ["derive", "wrap_help", "env"] }
+log = { version = "0.4" }
 rand = "0.8"
+serde = { version = "1.0", features = [ "derive" ] }
 utils = { path = "utils" }
 
 [dev-dependencies]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 smithay-client-toolkit = { version = "0.16", default-features = false, features = ["calloop"] }
 log = { version = "0.4", features = ["max_level_debug", "release_max_level_info"] }
-simplelog = "0.12"
 keyframe = "1.1"
 
 utils = { path = "../utils" }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1,5 +1,4 @@
 use log::{debug, error, info, warn};
-use simplelog::{ColorChoice, LevelFilter, TermLogger, TerminalMode, ThreadLogMode};
 
 use smithay_client_toolkit::{
     environment::Environment,
@@ -32,6 +31,7 @@ use std::{
 use utils::{
     communication::{get_socket_path, Answer, BgImg, BgInfo, Clear, Img, Request},
     comp_decomp::ReadiedPack,
+    make_logger,
 };
 
 mod processor;
@@ -258,21 +258,6 @@ fn main() -> Result<(), String> {
 
     info!("Goodbye!");
     Ok(())
-}
-
-fn make_logger() {
-    let config = simplelog::ConfigBuilder::new()
-        .set_thread_level(LevelFilter::Info) //let me see where the processing is happening
-        .set_thread_mode(ThreadLogMode::Both)
-        .build();
-
-    TermLogger::init(
-        LevelFilter::Debug,
-        config,
-        TerminalMode::Stderr,
-        ColorChoice::AlwaysAnsi,
-    )
-    .expect("Failed to initialize logger. Cancelling...");
 }
 
 fn create_backgrounds(

--- a/src/animation_cache.rs
+++ b/src/animation_cache.rs
@@ -1,0 +1,146 @@
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+    io::{BufReader, BufWriter},
+    path::PathBuf,
+    time::Duration,
+};
+
+use utils::{communication::get_cache_path, comp_decomp::BitPack};
+
+use log::{debug, error};
+
+use crate::cli::Img;
+
+const VERSION: u32 = 1;
+
+#[derive(serde::Deserialize)]
+pub struct CachedAnimation {
+    version: u32,
+    hash: u64,
+    pub animation: Box<[(BitPack, Duration)]>,
+}
+
+// Only used for serialization.
+//
+// The difference to [`CachedAnimation`] is that this type does not own it's data
+// so that it doesn't have to be cloned or moved.
+#[derive(serde::Serialize)]
+struct CachedAnimationRef<'a> {
+    version: u32,
+    hash: u64,
+    animation: &'a [(BitPack, Duration)],
+}
+
+pub struct AnimationCache {
+    cache_dir: PathBuf,
+}
+
+impl AnimationCache {
+    pub fn init() -> Result<Self, String> {
+        let cache_dir = get_cache_path()?.join("animations");
+        if !cache_dir.is_dir() {
+            if let Err(e) = std::fs::create_dir(&cache_dir) {
+                return Err(format!(
+                    "failed to create cache_path \"{}\": {e}",
+                    cache_dir.display()
+                ));
+            }
+        }
+        Ok(Self { cache_dir })
+    }
+
+    fn hash(&self, img: &Img, dim: &(u32, u32)) -> (PathBuf, u64) {
+        let mut hasher = DefaultHasher::new();
+        img.path.hash(&mut hasher);
+        dim.hash(&mut hasher);
+        img.filter.hash(&mut hasher);
+        img.no_resize.hash(&mut hasher);
+        img.fill_color.hash(&mut hasher);
+
+        let hash = hasher.finish();
+
+        let name = format!("{:0x}.swww-cache", hash);
+        let path = self.cache_dir.join(name);
+
+        (path, hash)
+    }
+
+    pub fn load(&self, img: &Img, dim: &(u32, u32)) -> Result<Option<CachedAnimation>, String> {
+        let (cache_path, hash) = self.hash(img, dim);
+        if cache_path.is_file() {
+            debug!("loading cached animation from {}", cache_path.display());
+            let cache_file = std::fs::File::open(&cache_path).map_err(|e| {
+                format!(
+                    "cannot open image cache file from {}: {}",
+                    cache_path.display(),
+                    e
+                )
+            })?;
+            match bincode::deserialize_from::<_, CachedAnimation>(BufReader::new(cache_file)) {
+                Ok(cache) => {
+                    debug!("loaded cached animation from {}", cache_path.display());
+                    if cache.version != VERSION {
+                        error!(
+                            "invalid version. Expected {} but got {}",
+                            VERSION, cache.version,
+                        );
+                        return Ok(None);
+                    }
+                    if cache.hash != hash {
+                        error!(
+                            "invalid hash in {}. Expected {} but got {}",
+                            cache_path.display(), hash, cache.hash,
+                        );
+                        return Ok(None);
+                    }
+                    return Ok(Some(cache));
+                }
+                Err(e) => {
+                    error!(
+                        "failed to load image cache for {}: {}",
+                        cache_path.display(),
+                        e
+                    );
+                }
+            }
+        }
+        debug!("no cached animation found for {}", cache_path.display());
+
+        Ok(None)
+    }
+
+    pub fn save(
+        &self,
+        img: &crate::cli::Img,
+        dim: &(u32, u32),
+        animation: &[(BitPack, Duration)],
+    ) -> Result<(), String> {
+        let (cache_path, hash) = self.hash(img, dim);
+        debug!("caching animation to {}", cache_path.display());
+        let cache_file = std::fs::File::create(&cache_path).map_err(|e| {
+            format!(
+                "cannot open image cache file from {}: {}",
+                cache_path.display(),
+                e
+            )
+        })?;
+        if let Err(e) = bincode::serialize_into(
+            BufWriter::new(cache_file),
+            &CachedAnimationRef {
+                animation,
+                version: VERSION,
+                hash,
+            },
+        ) {
+            error!(
+                "failed to load image cache for {}: {}",
+                cache_path.display(),
+                e
+            );
+        }
+        debug!("cached animation to {}", cache_path.display());
+
+        Ok(())
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,7 +36,7 @@ fn from_hex(hex: &str) -> Result<[u8; 3], String> {
     Ok(color)
 }
 
-#[derive(Clone)]
+#[derive(Clone, Hash)]
 pub enum Filter {
     Nearest,
     Bilinear,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,12 +14,14 @@ use std::{
 use utils::{
     communication::{self, get_socket_path, AnimationRequest, Answer, Coord, Position, Request},
     comp_decomp::BitPack,
+    make_logger,
 };
 
 mod cli;
 use cli::Swww;
 
 fn main() -> Result<(), String> {
+    make_logger();
     let swww = Swww::parse();
     if let Swww::Init { no_daemon } = &swww {
         match is_daemon_running() {

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 lazy_static = "1.4"
 lzzzz = "=1.0.4"
 serde = { version = "1.0", features = [ "derive" ] }
+simplelog = "0.12"
 bincode = "1.3"
 
 [dev-dependencies]

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,2 +1,19 @@
+use simplelog::{ColorChoice, LevelFilter, TermLogger, TerminalMode, ThreadLogMode};
+
 pub mod communication;
 pub mod comp_decomp;
+
+pub fn make_logger() {
+    let config = simplelog::ConfigBuilder::new()
+        .set_thread_level(LevelFilter::Info) //let me see where the processing is happening
+        .set_thread_mode(ThreadLogMode::Both)
+        .build();
+
+    TermLogger::init(
+        LevelFilter::Debug,
+        config,
+        TerminalMode::Stderr,
+        ColorChoice::AlwaysAnsi,
+    )
+    .expect("Failed to initialize logger. Cancelling...");
+}


### PR DESCRIPTION
swww caches images which takes a really long time for large gifs.
A 160 MB gif takes around 3 minutes to compress.
Taking that long and eating a complete resource is unnecessary because
most switched wallpapers are used more than once.
This commit caches the compressed frames in the `.cache` directory
so that next time the frames can be reused without compression again
(it takes around 3s to load the cache).

Note that the cache is somewhat conservative, if you change some
properties of the animation of the gif it will likely recompress. 
This could be improved in the future but I wanted to be sure that no
outdated animations are displayed.

I don't know if this is a too big feature but for me it is really helpful and I didn't know a way to implement this in a shell wrapper.

If you have any improvements/ suggestions, please say so!