### PR TITLE
add flag to invert the y value from --transition-pos

### DIFF
--- a/daemon/src/processor/animations.rs
+++ b/daemon/src/processor/animations.rs
@@ -41,6 +41,7 @@ pub struct Transition {
     pos: Position,
     bezier: BezierCurve,
     wave: (f32, f32),
+    invert_y: bool,
 }
 
 /// All transitions return whether or not they completed
@@ -70,6 +71,7 @@ impl Transition {
                 },
             ),
             wave: transition.wave,
+            invert_y: transition.invert_y,
         }
     }
 
@@ -266,7 +268,7 @@ impl Transition {
     ) {
         let fps = self.fps;
         let (width, height) = (self.dimensions.0 as f32, self.dimensions.1 as f32);
-        let (center_x, center_y) = self.pos.to_pixel(self.dimensions);
+        let (center_x, center_y) = self.pos.to_pixel(self.dimensions,self.invert_y);
         let mut dist_center: f32 = 0.0;
         let dist_end: f32 = {
             let mut x = center_x;
@@ -320,7 +322,7 @@ impl Transition {
     ) {
         let fps = self.fps;
         let (width, height) = (self.dimensions.0 as f32, self.dimensions.1 as f32);
-        let (center_x, center_y) = self.pos.to_pixel(self.dimensions);
+        let (center_x, center_y) = self.pos.to_pixel(self.dimensions,self.invert_y);
         let mut dist_center = {
             let mut x = center_x;
             let mut y = center_y;
@@ -421,6 +423,7 @@ mod tests {
             pos: Position::new(Coord::Percent(0.0), Coord::Percent(0.0)),
             bezier: BezierCurve::from(Vector2 { x: 1.0, y: 0.0 }, Vector2 { x: 0.0, y: 1.0 }),
             wave: (20.0, 20.0),
+            invert_y: false,
         }
     }
 

--- a/doc/swww-img.1.scd
+++ b/doc/swww-img.1.scd
@@ -165,6 +165,11 @@ swww-img
 
 	Default is _center_.
 
+*--invert-y* <bool>
+	\[Environment Variable: SWWW_INVERT_Y]
+
+	inverts the y position sent in `transiiton_pos` flag
+
 *--transition-bezier* <f1,f2,f3,f4 (all floats)>
 	\[Environment Variable: SWWW_TRANSITION_BEZIER]
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -310,6 +310,10 @@ pub struct Img {
     #[arg(long, env = "SWWW_TRANSITION_POS", default_value = "center", value_parser=parse_coords)]
     pub transition_pos: CliPosition,
 
+    /// inverts the y position sent in 'transiiton_pos' flag
+    #[arg(long, env = "INVERT_Y", default_value = "false")]
+    pub invert_y: bool,
+
     ///bezier curve to use for the transition
     ///https://cubic-bezier.com is a good website to get these values from
     ///
@@ -320,6 +324,8 @@ pub struct Img {
     ///currently only used for 'wave' transition to control the width and height of each wave
     #[arg(long, env = "SWWW_TRANSITION_WAVE", default_value = "20,20", value_parser = parse_wave)]
     pub transition_wave: (f32, f32),
+
+
 }
 
 fn parse_wave(raw: &str) -> Result<(f32, f32), String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -519,6 +519,7 @@ fn make_transition(img: &cli::Img) -> communication::Transition {
         pos,
         transition_type,
         wave: img.transition_wave,
+        invert_y: img.invert_y,
     }
 }
 

--- a/utils/src/communication.rs
+++ b/utils/src/communication.rs
@@ -43,7 +43,7 @@ impl Position {
             },
             Coord::Percent(y) => {
                 if invert_y {
-                    dim.1 as f32 - y * dim.1 as f32
+                    (1.0 - y) * dim.1 as f32
                 } else {
                     y * dim.1 as f32
                 }

--- a/utils/src/communication.rs
+++ b/utils/src/communication.rs
@@ -27,15 +27,27 @@ impl Position {
         Self { x, y }
     }
 
-    pub fn to_pixel(&self, dim: (u32, u32)) -> (f32, f32) {
+    pub fn to_pixel(&self, dim: (u32, u32), invert_y: bool) -> (f32, f32) {
         let x = match self.x {
             Coord::Pixel(x) => x,
             Coord::Percent(x) => x * dim.0 as f32,
         };
 
         let y = match self.y {
-            Coord::Pixel(y) => y,
-            Coord::Percent(y) => y * dim.1 as f32,
+            Coord::Pixel(y) => {
+                if invert_y {
+                    dim.1 as f32 - y
+                } else {
+                    y
+                }
+            },
+            Coord::Percent(y) => {
+                if invert_y {
+                    dim.1 as f32 - y * dim.1 as f32
+                } else {
+                    y * dim.1 as f32
+                }
+            },
         };
 
         (x, y)
@@ -122,6 +134,7 @@ pub struct Transition {
     pub pos: Position,
     pub bezier: (f32, f32, f32, f32),
     pub wave: (f32, f32),
+    pub invert_y: bool,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
add `--invert-y` flag

inverts the y value that is received from the transition-pos flag

fixes #127