### PR TITLE
wait for daemon to config outputs on `swww init`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,7 +1343,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "swww"
-version = "0.8.1"
+version = "0.8.1-master"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "swww-daemon"
-version = "0.8.1"
+version = "0.8.1-master"
 dependencies = [
  "keyframe",
  "log",

--- a/daemon/src/wallpaper.rs
+++ b/daemon/src/wallpaper.rs
@@ -60,6 +60,7 @@ pub struct Wallpaper {
 
     animation_state: AnimationState,
     pool: Arc<Mutex<SlotPool>>,
+    pub configured: AtomicBool,
 }
 
 impl Wallpaper {
@@ -119,6 +120,7 @@ impl Wallpaper {
                 id: AtomicUsize::new(0),
                 transition_finished: Arc::new(AtomicBool::new(false)),
             },
+            configured: AtomicBool::new(false)
         }
     }
 
@@ -264,5 +266,6 @@ impl Wallpaper {
             .set_size(inner.width.get() as u32, inner.height.get() as u32);
         inner.img = BgImg::Color([0, 0, 0]);
         self.layer_surface.commit();
+        self.configured.store(false, Ordering::Release);
     }
 }

--- a/utils/src/ipc.rs
+++ b/utils/src/ipc.rs
@@ -272,6 +272,7 @@ pub enum Answer {
     Ok,
     Err(String),
     Info(Box<[BgInfo]>),
+    Init(bool),
 }
 
 impl Answer {


### PR DESCRIPTION
This implements a waiting mechanism, whereby the client wait until the daemon return Answer::Init(true) before exiting. It might help us with some very, very nasty race-conditions that keep happening lately (#144)