### PR TITLE
fix doc gen and Cargo.lock file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,7 +1343,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "swww"
-version = "0.8.1"
+version = "0.8.1-master"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "swww-daemon"
-version = "0.8.1"
+version = "0.8.1-master"
 dependencies = [
  "keyframe",
  "log",

--- a/doc/swww-init.1.scd
+++ b/doc/swww-init.1.scd
@@ -16,10 +16,10 @@ swww-init
 	much (ideally). This is mostly useful for debugging and developing.
 
 *--no-cache*
-    Don't load the cache *during initialization* (it still loads on monitor (re)connection)
+	Don't load the cache *during initialization* (it still loads on monitor (re)connection)
 
-    If want to always pass an image for `swww` to load, this option can help make the
-    results some reliable: `swww init --no-cache && swww img <some img>`
+	If want to always pass an image for `swww` to load, this option can help make the
+	results some reliable: `swww init --no-cache && swww img <some img>`
 
 *-h*, *--help*
 	Print help (see a summary with '-h')


### PR DESCRIPTION
since #147 the build script for [swww-git on the aur](https://aur.archlinux.org/packages/swww-git) stopped working due to two reasons

* a version mismatch between Cargo.toml and Cargo.lock caused `cargo fetch --locked` to fail
* executing `./doc/gen.sh` complained about tabs being requiered for indentation in ./doc/swww-init.1.scd

this pr updates the Cargo.lock file and replaces the 4-space indentation in ./doc/swww-init.1.scd with tabs