### PR TITLE
Fix wrong env variable name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ swww img <path/to/img> --transition-step <1 to 255> --transition-fps <1 to 255>
 swww img <path/to/img> --transition-type center
 
 # Note you may also control the above by setting up the SWWW_TRANSITION_FPS,
-# SWWW_TRANSITION_STEP, and SWWW_TRANSITION_TYPE environment variables.
+# SWWW_TRANSITION_STEP, and SWWW_TRANSITION environment variables.
 
 # To see all options, run
 swww img --help


### PR DESCRIPTION
[The code looks for SWWW_TRANSITION (and not SWWW_TRANSITION_TYPE)](https://github.com/Horus645/swww/blob/517fbeb0f831d43d6c88dac22380536b00e7d9f1/src/cli.rs#L286).

Not sure if the code is wrong, or the documentation is wrong. Either way, this is the way it works now.