### PR TITLE
Add msrv to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ name = "swww"
 version = "0.8.1"
 authors = ["Leonardo Gibrowski Faé <leonardo.fae44@gmail.com>"]
 edition = "2021"
+# we use `std::cell::OnceLock` which was stabilized in 1.70
+rust-version = "1.70"
 
 [profile.release]
 debug = 0


### PR DESCRIPTION
The `rust-version` field ensures that older rust compilers emit an error with a clearer message that a newer compiler is required.

See https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field

Error message:
```
error: package `swww v0.8.1 (/path/to/swww)` cannot be built because it requires rustc 1.70 or newer, while the currently active rustc version is 1.68.2
````

see #165 