### PR TITLE
docs: fix TRANSITION_TYPE in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ swww img <path/to/img> --transition-step <1 to 255> --transition-fps <1 to 255>
 swww img <path/to/img> --transition-type center
 
 # Note you may also control the above by setting up the SWWW_TRANSITION_FPS,
-# SWWW_TRANSITION_STEP, and SWWW_TRANSITION_TYPE environment variables.
+# SWWW_TRANSITION_STEP, and SWWW_TRANSITION environment variables.
 
 # To see all options, run
 swww img --help


### PR DESCRIPTION
The actual name of the variable is SWWW_TRANSITION and not SWWW_TRANSITION_TYPE for transition type.